### PR TITLE
Add Filter & Enrich Support For ASP.NET Instrumented Metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -6,8 +6,16 @@ OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.get -> 
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.AspNetMetricEnrichmentFunc
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.AspNetMetricsInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.get -> OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.AspNetMetricEnrichmentFunc?
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Enrich.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Filter.get -> System.Func<string!, System.Web.HttpContext!, bool>?
+OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Metrics.MeterProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
+static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetMetricsInstrumentationOptions!>? configure) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions!>? configure) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
@@ -38,6 +38,7 @@ internal sealed class AspNetMetrics : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="AspNetMetrics"/> class.
     /// </summary>
+    /// <param name="options">Allows users to define any filtering or enrichment functionality.</param>
     public AspNetMetrics(AspNetMetricsInstrumentationOptions options)
     {
         Guard.ThrowIfNull(options);

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.AspNet;
 
@@ -37,10 +38,11 @@ internal sealed class AspNetMetrics : IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="AspNetMetrics"/> class.
     /// </summary>
-    public AspNetMetrics()
+    public AspNetMetrics(AspNetMetricsInstrumentationOptions options)
     {
+        Guard.ThrowIfNull(options);
         this.meter = new Meter(InstrumentationName, InstrumentationVersion);
-        this.httpInMetricsListener = new HttpInMetricsListener(this.meter);
+        this.httpInMetricsListener = new HttpInMetricsListener(this.meter, options);
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
@@ -1,8 +1,28 @@
+// <copyright file="AspNetMetricsInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
 using System;
 using System.Diagnostics;
 using System.Web;
 
 namespace OpenTelemetry.Instrumentation.AspNet;
+
+/// <summary>
+/// Options for ASP.NET metrics instrumentation.
+/// </summary>
 public class AspNetMetricsInstrumentationOptions
 {
     /// <summary>
@@ -31,10 +51,10 @@ public class AspNetMetricsInstrumentationOptions
     /// </list></item>
     /// </list>
     /// </remarks>
-    public Func<string, HttpContext, bool> Filter { get; set; }
+    public Func<string, HttpContext, bool>? Filter { get; set; }
 
     /// <summary>
     /// Gets or sets an function to enrich a recorded metric with additional custom tags.
     /// </summary>
-    public AspNetMetricEnrichmentFunc Enrich { get; set; }
+    public AspNetMetricEnrichmentFunc? Enrich { get; set; }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace OpenTelemetry.Instrumentation.AspNet;
+public class AspNetMetricsInstrumentationOptions
+{
+    /// <summary>
+    /// Delegate for enrichment of recorded metric with additional tags.
+    /// </summary>
+    /// <param name="context"><see cref="HttpContext"/>: the HttpContext object. Both Request and Response are available.</param>
+    /// <param name="tags"><see cref="TagList"/>: List of current tags. You can add additional tags to this list. </param>
+    public delegate void AspNetMetricEnrichmentFunc(string name, HttpContext context, ref TagList tags);
+
+    /// <summary>
+    /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
+    /// The Filter gets the HttpContext, and should return a boolean.
+    /// If Filter returns true, the request is collected.
+    /// If Filter returns false or throw exception, the request is filtered out.
+    /// </summary>
+    public Func<HttpContext, bool> Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets an function to enrich a recorded metric with additional custom tags.
+    /// </summary>
+    public AspNetMetricEnrichmentFunc Enrich { get; set; }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetricsInstrumentationOptions.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web;
 
 namespace OpenTelemetry.Instrumentation.AspNet;
@@ -12,17 +8,30 @@ public class AspNetMetricsInstrumentationOptions
     /// <summary>
     /// Delegate for enrichment of recorded metric with additional tags.
     /// </summary>
+    /// <param name="metricName">The name of the metric being enriched.</param>
     /// <param name="context"><see cref="HttpContext"/>: the HttpContext object. Both Request and Response are available.</param>
     /// <param name="tags"><see cref="TagList"/>: List of current tags. You can add additional tags to this list. </param>
-    public delegate void AspNetMetricEnrichmentFunc(string name, HttpContext context, ref TagList tags);
+    public delegate void AspNetMetricEnrichmentFunc(string metricName, HttpContext context, ref TagList tags);
 
     /// <summary>
-    /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
-    /// The Filter gets the HttpContext, and should return a boolean.
-    /// If Filter returns true, the request is collected.
-    /// If Filter returns false or throw exception, the request is filtered out.
+    /// Gets or sets a filter function that determines whether or not to
+    /// collect telemetry on a per request basis.
     /// </summary>
-    public Func<HttpContext, bool> Filter { get; set; }
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>The first parameter is the name of the metric being
+    /// filtered.</item>
+    /// <item>The return value for the filter function is interpreted as:
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true" />, the request is
+    /// collected.</item>
+    /// <item>If filter returns <see langword="false" /> or throws an
+    /// exception the request is NOT collected.</item>
+    /// </list></item>
+    /// </list>
+    /// </remarks>
+    public Func<string, HttpContext, bool> Filter { get; set; }
 
     /// <summary>
     /// Gets or sets an function to enrich a recorded metric with additional custom tags.

--- a/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using OpenTelemetry.Instrumentation.AspNet;
 using OpenTelemetry.Internal;
 
@@ -24,17 +25,30 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public static class MeterProviderBuilderExtensions
 {
+
     /// <summary>
     /// Enables the incoming requests automatic data collection for ASP.NET.
     /// </summary>
     /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
     /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddAspNetInstrumentation(this MeterProviderBuilder builder) =>
+    AddAspNetInstrumentation(builder, configure: null);
+
+    /// <summary>
+    /// Enables the incoming requests automatic data collection for ASP.NET.
+    /// </summary>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+    /// <param name="configure">ASP.NET Request configuration options.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
     public static MeterProviderBuilder AddAspNetInstrumentation(
-        this MeterProviderBuilder builder)
+        this MeterProviderBuilder builder, Action<AspNetMetricsInstrumentationOptions> configure)
     {
         Guard.ThrowIfNull(builder);
 
+        var aspnetMetricsOptions = new AspNetMetricsInstrumentationOptions();
+        configure?.Invoke(aspnetMetricsOptions);
+
         builder.AddMeter(AspNetMetrics.InstrumentationName);
-        return builder.AddInstrumentation(() => new AspNetMetrics());
+        return builder.AddInstrumentation(() => new AspNetMetrics(aspnetMetricsOptions));
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
@@ -25,7 +25,6 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public static class MeterProviderBuilderExtensions
 {
-
     /// <summary>
     /// Enables the incoming requests automatic data collection for ASP.NET.
     /// </summary>
@@ -41,7 +40,7 @@ public static class MeterProviderBuilderExtensions
     /// <param name="configure">ASP.NET Request configuration options.</param>
     /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
     public static MeterProviderBuilder AddAspNetInstrumentation(
-        this MeterProviderBuilder builder, Action<AspNetMetricsInstrumentationOptions> configure)
+        this MeterProviderBuilder builder, Action<AspNetMetricsInstrumentationOptions>? configure)
     {
         Guard.ThrowIfNull(builder);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Web;
 using OpenTelemetry.Context.Propagation;
@@ -107,5 +108,288 @@ public class HttpInMetricsListenerTests
         Assert.Equal("GET", httpMethod);
         Assert.Equal(200, httpStatusCode);
         Assert.Equal("http", httpScheme);
+    }
+
+    [Fact]
+    public void HttpDurationMetricIsEmittedWithEnrichments()
+    {
+        // Custom tag that will be added to the http.server.duration metric's TagList
+        KeyValuePair<string, object?> testTag = new("testTagKey", "testTagValue");
+
+        string url = "http://localhost/api/value";
+        double duration = 0;
+        HttpContext.Current = new HttpContext(
+            new HttpRequest(string.Empty, url, string.Empty),
+            new HttpResponse(new StringWriter()));
+
+        // This is to enable activity creation
+        // as it is created using ActivitySource inside TelemetryHttpModule
+        // TODO: This should not be needed once the dependency on activity is removed from metrics
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddAspNetInstrumentation(opts => opts.Enrich
+                = (activity, eventName, rawObject) =>
+                {
+                    if (eventName.Equals("OnStopActivity"))
+                    {
+                        duration = activity.Duration.TotalMilliseconds;
+                    }
+                })
+            .Build();
+
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAspNetInstrumentation(options =>
+            {
+                options.Enrich = (string metricName, HttpContext httpContext, ref TagList tags) =>
+                {
+                    // If we're emitting an http.server.duration metric...
+                    if (metricName == "http.server.duration")
+                    {
+                        // Enrich it with the given custom tag.
+                        tags.Add(testTag);
+                    }
+                };
+            })
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var activity = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        meterProvider.ForceFlush();
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (var p in exportedItems[0].GetMetricPoints())
+        {
+            metricPoints.Add(p);
+        }
+
+        Assert.Single(metricPoints);
+
+        var metricPoint = metricPoints[0];
+
+        var count = metricPoint.GetHistogramCount();
+        var sum = metricPoint.GetHistogramSum();
+
+        Assert.Equal(MetricType.Histogram, exportedItems[0].MetricType);
+        Assert.Equal("http.server.duration", exportedItems[0].Name);
+        Assert.Equal(1L, count);
+        Assert.Equal(duration, sum);
+
+        Assert.Equal(4, metricPoints[0].Tags.Count);
+        string? httpMethod = null;
+        int httpStatusCode = 0;
+        string? httpScheme = null;
+        string? testTagVal = null;
+
+        foreach (var tag in metricPoints[0].Tags)
+        {
+            if (tag.Key == SemanticConventions.AttributeHttpMethod)
+            {
+                httpMethod = (string)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeHttpStatusCode)
+            {
+                httpStatusCode = (int)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeHttpScheme)
+            {
+                httpScheme = (string)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == testTag.Key)
+            {
+                testTagVal = (string)tag.Value;
+                continue;
+            }
+        }
+
+        Assert.Equal("GET", httpMethod);
+        Assert.Equal(200, httpStatusCode);
+        Assert.Equal("http", httpScheme);
+        Assert.Equal(testTag.Value, testTagVal);
+    }
+
+    [Fact]
+    public void HttpDurationMetricIsFiltered()
+    {
+        // Make two "requests" and filter the http.server.duration to only collect
+        // metrics for one of the given URLs.
+        string url1 = "http://localhost/api/filterout";
+        string url2 = "http://localhost/api/collect";
+        double duration = 0;
+        HttpContext.Current = new HttpContext(
+            new HttpRequest(string.Empty, url1, string.Empty),
+            new HttpResponse(new StringWriter()));
+
+        // This is to enable activity creation
+        // as it is created using ActivitySource inside TelemetryHttpModule
+        // TODO: This should not be needed once the dependency on activity is removed from metrics
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddAspNetInstrumentation(opts => opts.Enrich
+                = (activity, eventName, rawObject) =>
+                {
+                    if (eventName.Equals("OnStopActivity"))
+                    {
+                        duration = activity.Duration.TotalMilliseconds;
+                    }
+                })
+            .Build();
+
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAspNetInstrumentation(options =>
+            {
+                options.Filter = (string metricName, HttpContext httpContext) =>
+                {
+                    // If the request hits a given URL, we shouldn't emit a metric.
+                    return httpContext.Request.Url.AbsoluteUri != url1;
+                };
+            })
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var activity1 = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity1, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        HttpContext.Current = new HttpContext(
+            new HttpRequest(string.Empty, url2, string.Empty),
+            new HttpResponse(new StringWriter()));
+
+        var activity2 = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity2, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        meterProvider.ForceFlush();
+
+        // We should've only collected one metric
+        Assert.Single(exportedItems);
+    }
+
+    [Fact]
+    public void HttpDurationMetricIsEmittedWithEnrichmentsAndFiltered()
+    {
+        // Custom tag that will be added to the http.server.duration metric's TagList
+        KeyValuePair<string, object?> testTag = new("testTagKey", "testTagValue");
+
+        // Make two "requests" and filter the http.server.duration to only collect
+        // metrics for one of the given URLs.
+        string url1 = "http://localhost/api/filterout";
+        string url2 = "http://localhost/api/collect";
+        double duration = 0;
+        HttpContext.Current = new HttpContext(
+            new HttpRequest(string.Empty, url1, string.Empty),
+            new HttpResponse(new StringWriter()));
+
+        // This is to enable activity creation
+        // as it is created using ActivitySource inside TelemetryHttpModule
+        // TODO: This should not be needed once the dependency on activity is removed from metrics
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddAspNetInstrumentation(opts => opts.Enrich
+                = (activity, eventName, rawObject) =>
+                {
+                    if (eventName.Equals("OnStopActivity"))
+                    {
+                        duration = activity.Duration.TotalMilliseconds;
+                    }
+                })
+            .Build();
+
+        var exportedItems = new List<Metric>();
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddAspNetInstrumentation(options =>
+            {
+                options.Enrich = (string metricName, HttpContext httpContext, ref TagList tags) =>
+                {
+                    // If we're emitting an http.server.duration metric...
+                    if (metricName == "http.server.duration")
+                    {
+                        // Enrich it with the given custom tag.
+                        tags.Add(testTag);
+                    }
+                };
+                options.Filter = (string metricName, HttpContext httpContext) =>
+                {
+                    // If the request hits a given URL, we shouldn't emit a metric.
+                    return httpContext.Request.Url.AbsoluteUri != url1;
+                };
+            })
+            .AddInMemoryExporter(exportedItems)
+            .Build();
+
+        var activity1 = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity1, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        HttpContext.Current = new HttpContext(
+            new HttpRequest(string.Empty, url2, string.Empty),
+            new HttpResponse(new StringWriter()));
+
+        var activity2 = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+        ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity2, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+        meterProvider.ForceFlush();
+
+        // We should've only collected one metric
+        Assert.Single(exportedItems);
+
+        var metricPoints = new List<MetricPoint>();
+        foreach (var p in exportedItems[0].GetMetricPoints())
+        {
+            metricPoints.Add(p);
+        }
+
+        Assert.Single(metricPoints);
+
+        var metricPoint = metricPoints[0];
+
+        var count = metricPoint.GetHistogramCount();
+        var sum = metricPoint.GetHistogramSum();
+
+        Assert.Equal(MetricType.Histogram, exportedItems[0].MetricType);
+        Assert.Equal("http.server.duration", exportedItems[0].Name);
+        Assert.Equal(1L, count);
+        Assert.Equal(duration, sum);
+
+        Assert.Equal(4, metricPoints[0].Tags.Count);
+        string? httpMethod = null;
+        int httpStatusCode = 0;
+        string? httpScheme = null;
+        string? testTagVal = null;
+
+        foreach (var tag in metricPoints[0].Tags)
+        {
+            if (tag.Key == SemanticConventions.AttributeHttpMethod)
+            {
+                httpMethod = (string)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeHttpStatusCode)
+            {
+                httpStatusCode = (int)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == SemanticConventions.AttributeHttpScheme)
+            {
+                httpScheme = (string)tag.Value;
+                continue;
+            }
+
+            if (tag.Key == testTag.Key)
+            {
+                testTagVal = (string)tag.Value;
+                continue;
+            }
+        }
+
+        Assert.Equal("GET", httpMethod);
+        Assert.Equal(200, httpStatusCode);
+        Assert.Equal("http", httpScheme);
+        Assert.Equal(testTag.Value, testTagVal);
     }
 }


### PR DESCRIPTION
## Changes

This PR adds AspNetMetricsInstrumentationOptions with the ability to filter and enrich emitted metrics to the OpenTelemetry.Instrumentation.AspNet package. These changes are meant to match those already available in the AspNetCore instrumentation library and based on this PR: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3948

The main use case for this is that services can rely on the out-of-the-box instrumentation to emit the "http.server.duration" metric while adding custom tags (in our case these may be "Region", "Cluster", etc.). This would be preferred to building custom handlers and middleware to publish a separate metric with custom tags.

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
